### PR TITLE
chore: add GitHub CI for Building JAR Files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
           java-version: 21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+      - name: Create wrapper
+        run: gradle wrapper
       - name: Build with Gradle
         run: ./gradlew build
       - name: Create JAR file

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build and Upload Artifact
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Build with Gradle
+        run: ./gradlew build
+      - name: Create JAR file
+        run: ./gradlew shadowJar
+      - name: Upload JAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: JAR Files
+          path: build/libs/*.jar


### PR DESCRIPTION
The purpose of this is to allow people to get the JAR file of the plugin without them having to build the project themselves. This also allow people to try the test builds of this plugin.

The JAR Files will be created and uploaded as an artifact:
![image](https://github.com/user-attachments/assets/e677a0f2-9661-4573-b38d-b79724597699)
![image](https://github.com/user-attachments/assets/9f447538-65d2-486e-a85e-2a26a652cc8f)
